### PR TITLE
Set default width and height for BoostrapIconTagHelper

### DIFF
--- a/BootstrapIcons.AspNetCore/BoostrapIconTagHelper.cs
+++ b/BootstrapIcons.AspNetCore/BoostrapIconTagHelper.cs
@@ -21,6 +21,16 @@ namespace BootstrapIcons.AspNetCore
                 return;
             }
 
+            if (output.Attributes.All(x => x.Name != "width"))
+            {
+                output.Attributes.SetAttribute("width", "1em");
+            }
+
+            if (output.Attributes.All(x => x.Name != "height"))
+            {
+                output.Attributes.SetAttribute("height", "1em");
+            }
+        
             output.Attributes.SetAttribute("xmlns", "");
             output.Attributes.SetAttribute("fill", "currentColor");
             output.Attributes.SetAttribute("focusable", "false");


### PR DESCRIPTION
I would like to propose setting a default width and height of `1em` to the svg tag output to reduce cumulative layout shift if no width or height is manually specified, which would be useful for inlining with text, or is adjusted by any CSS rules that may be loaded on a page.

Various icon libraries in JS (e.g. Iconify) use these width and height values as the default, too.